### PR TITLE
CSP configuration with netlify CSP plugin

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link'
+
+export default function NotFound() {
+  return (
+    <main className="flex min-h-screen items-center justify-center bg-white px-6 text-neutral-900">
+      <div className="max-w-md text-center">
+        <p className="text-sm font-bold uppercase tracking-[0.18em] text-blue-700">
+          404
+        </p>
+        <h1 className="mt-4 text-4xl font-bold">Page not found</h1>
+        <p className="mt-4 leading-7 text-neutral-600">
+          The page you requested does not exist or has moved.
+        </p>
+        <Link
+          className="mt-8 inline-flex min-h-11 items-center justify-center rounded-lg bg-blue-700 px-5 text-sm font-semibold text-white transition-colors hover:bg-neutral-900"
+          href="/"
+        >
+          Return home
+        </Link>
+      </div>
+    </main>
+  )
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,22 @@
   command = "next build"
   publish = "out"
 
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Content-Security-Policy = "default-src 'self'; script-src 'self' https://kumuluz.us12.list-manage.com; style-src 'self'; style-src-attr 'none'; img-src 'self'; font-src 'self'; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'self' https://kumuluz.us12.list-manage.com; manifest-src 'self'; worker-src 'self'"
+
+[[plugins]]
+  package = "@netlify/plugin-csp-nonce"
+  [plugins.inputs]
+    reportOnly = false
+    strictDynamic = true
+    unsafeEval = false
+    unsafeInline = false
+    self = true
+    https = false
+    http = false
+
 [[redirects]]
   from = "/interstore/lpc"
   to = "https://lpc.sunesis.si"

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 [[headers]]
   for = "/*"
   [headers.values]
-    Content-Security-Policy = "default-src 'self'; script-src 'self' https://kumuluz.us12.list-manage.com; style-src 'self'; style-src-attr 'none'; img-src 'self'; font-src 'self'; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'self' https://kumuluz.us12.list-manage.com; manifest-src 'self'; worker-src 'self'"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' https://kumuluz.us12.list-manage.com; style-src 'self'; style-src-attr 'none'; img-src 'self'; font-src 'self'; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src https://app.netlify.com; frame-ancestors 'none'; base-uri 'none'; form-action 'self' https://kumuluz.us12.list-manage.com; manifest-src 'self'; worker-src 'self'"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "camera=(), geolocation=(), microphone=(), payment=(), usb=()"

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,9 @@
   for = "/*"
   [headers.values]
     Content-Security-Policy = "default-src 'self'; script-src 'self' https://kumuluz.us12.list-manage.com; style-src 'self'; style-src-attr 'none'; img-src 'self'; font-src 'self'; connect-src 'self'; media-src 'self'; object-src 'none'; frame-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'self' https://kumuluz.us12.list-manage.com; manifest-src 'self'; worker-src 'self'"
+    X-Content-Type-Options = "nosniff"
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    Permissions-Policy = "camera=(), geolocation=(), microphone=(), payment=(), usb=()"
 
 [[plugins]]
   package = "@netlify/plugin-csp-nonce"
@@ -14,7 +17,7 @@
     strictDynamic = true
     unsafeEval = false
     unsafeInline = false
-    self = true
+    self = false
     https = false
     http = false
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@firecms/neat": "^1.0.0",
+        "@netlify/plugin-csp-nonce": "^1.6.2",
         "lucide-react": "^1.20.0",
         "motion": "^12.40.0",
         "next": "^16.2.9",
@@ -99,7 +100,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
@@ -241,7 +241,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -334,6 +333,64 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bugsnag/browser": {
+      "version": "7.25.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/@bugsnag/browser/-/browser-7.25.0.tgz",
+      "integrity": "sha512-PzzWy5d9Ly1CU1KkxTB6ZaOw/dO+CYSfVtqxVJccy832e6+7rW/dvSw5Jy7rsNhgcKSKjZq86LtNkPSvritOLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@bugsnag/core": "^7.25.0"
+      }
+    },
+    "node_modules/@bugsnag/core": {
+      "version": "7.25.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/@bugsnag/core/-/core-7.25.0.tgz",
+      "integrity": "sha512-JZLak1b5BVzy77CPcklViZrppac/pE07L3uSDmfSvFYSCGReXkik2txOgV05VlF9EDe36dtUAIIV7iAPDfFpQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@bugsnag/cuid": "^3.0.0",
+        "@bugsnag/safe-json-stringify": "^6.0.0",
+        "error-stack-parser": "^2.0.3",
+        "iserror": "0.0.2",
+        "stack-generator": "^2.0.3"
+      }
+    },
+    "node_modules/@bugsnag/cuid": {
+      "version": "3.2.2",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/@bugsnag/cuid/-/cuid-3.2.2.tgz",
+      "integrity": "sha512-7onuYLTMqMmHE9BBPG0YER4nFsU1rB+me1/YIeMusqcLbVbKKuG9u9+BDVDpje5e0llkkrVNOKYwmzM9DRIo7A==",
+      "license": "MIT"
+    },
+    "node_modules/@bugsnag/js": {
+      "version": "7.25.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/@bugsnag/js/-/js-7.25.0.tgz",
+      "integrity": "sha512-d8n8SyKdRUz8jMacRW1j/Sj/ckhKbIEp49+Dacp3CS8afRgfMZ//NXhUFFXITsDP5cXouaejR9fx4XVapYXNgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@bugsnag/browser": "^7.25.0",
+        "@bugsnag/node": "^7.25.0"
+      }
+    },
+    "node_modules/@bugsnag/node": {
+      "version": "7.25.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/@bugsnag/node/-/node-7.25.0.tgz",
+      "integrity": "sha512-KlxBaJ8EREEsfKInybAjTO9LmdDXV3cUH5+XNXyqUZrcRVuPOu4j4xvljh+n24ifok/wbFZTKVXUzrN4iKIeIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@bugsnag/core": "^7.25.0",
+        "byline": "^5.0.0",
+        "error-stack-parser": "^2.0.2",
+        "iserror": "^0.0.2",
+        "pump": "^3.0.0",
+        "stack-generator": "^2.0.3"
+      }
+    },
+    "node_modules/@bugsnag/safe-json-stringify": {
+      "version": "6.1.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.1.0.tgz",
+      "integrity": "sha512-ImA35rnM7bGr+J30R979FQ95BhRB4UO1KfJA0J2sVqc8nwnrS9hhE5mkTmQWMs8Vh1Da+hkLKs5jJB4JjNZp4A==",
+      "license": "MIT"
     },
     "node_modules/@dimforge/rapier3d-compat": {
       "version": "0.12.0",
@@ -579,7 +636,6 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
       "integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@img/colour": {
@@ -1117,6 +1173,189 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@netlify/build-info": {
+      "version": "8.1.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/@netlify/build-info/-/build-info-8.1.0.tgz",
+      "integrity": "sha512-VwEKqeynrVEGerOsErMfzlfTaE1IV9xOKnareDy1rdm+BEQAMyfwG1H+75G1M9JoCrNzLPn5kR3F61suOeBbfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@bugsnag/js": "^7.20.0",
+        "@iarna/toml": "^2.2.5",
+        "dot-prop": "^7.2.0",
+        "find-up": "^6.3.0",
+        "minimatch": "^9.0.0",
+        "read-pkg": "^7.1.0",
+        "semver": "^7.3.8",
+        "yaml": "^2.1.3",
+        "yargs": "^17.6.0"
+      },
+      "bin": {
+        "build-info": "bin.js"
+      },
+      "engines": {
+        "node": "^14.16.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@netlify/build-info/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/@netlify/build-info/node_modules/brace-expansion": {
+      "version": "2.1.2",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@netlify/build-info/node_modules/dot-prop": {
+      "version": "7.2.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/dot-prop/-/dot-prop-7.2.0.tgz",
+      "integrity": "sha512-Ol/IPXUARn9CSbkrdV4VJo7uCy1I3VuSiWCaFSg+8BdUOzF9n3jefIpcgAydvUZbTdEBZs2vEiTiS9m61ssiDA==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^2.11.2"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@netlify/build-info/node_modules/find-up": {
+      "version": "6.3.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/find-up/-/find-up-6.3.0.tgz",
+      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^7.1.0",
+        "path-exists": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@netlify/build-info/node_modules/locate-path": {
+      "version": "7.2.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/locate-path/-/locate-path-7.2.0.tgz",
+      "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^6.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@netlify/build-info/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@netlify/build-info/node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@netlify/build-info/node_modules/p-locate": {
+      "version": "6.0.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@netlify/build-info/node_modules/path-exists": {
+      "version": "5.0.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/path-exists/-/path-exists-5.0.0.tgz",
+      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/@netlify/build-info/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@netlify/build-info/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@netlify/build-info/node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@netlify/plugin-csp-nonce": {
+      "version": "1.6.2",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/@netlify/plugin-csp-nonce/-/plugin-csp-nonce-1.6.2.tgz",
+      "integrity": "sha512-d4DCoJmqXqtxIjTeJ7Hyo0d9EvF+9rEhSuiLYnUGa2pdkNI65PzO23TAgIdVpnqdpSiS8/PMfvvr5xoE1F418w==",
+      "license": "MIT",
+      "dependencies": {
+        "@netlify/build-info": "^8.0.0"
+      }
+    },
     "node_modules/@next/env": {
       "version": "16.2.9",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
@@ -1162,9 +1401,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1180,9 +1416,6 @@
       "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1200,9 +1433,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1218,9 +1448,6 @@
       "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1530,9 +1757,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1550,9 +1774,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1570,9 +1791,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1590,9 +1808,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1610,9 +1825,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1630,9 +1842,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1650,9 +1859,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1670,9 +1876,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1919,9 +2122,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1936,9 +2136,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1953,9 +2150,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1970,9 +2164,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1987,9 +2178,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2004,9 +2192,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2021,9 +2206,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2038,9 +2220,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2258,9 +2437,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2278,9 +2454,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2298,9 +2471,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2318,9 +2488,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2338,9 +2505,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2358,9 +2522,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2378,9 +2539,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2398,9 +2556,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3023,6 +3178,12 @@
         "undici-types": "~7.18.0"
       }
     },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
@@ -3438,6 +3599,21 @@
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/astring": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
@@ -3551,6 +3727,15 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/byline": {
+      "version": "5.0.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001799",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
@@ -3624,6 +3809,73 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -3822,6 +4074,21 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
       "version": "5.21.6",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
@@ -3849,6 +4116,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-stack-parser": {
+      "version": "2.1.4",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.2.0.tgz",
@@ -3860,7 +4145,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4271,6 +4555,15 @@
         }
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -4279,6 +4572,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -4327,6 +4629,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -4343,6 +4657,36 @@
       "dependencies": {
         "hermes-estree": "0.25.1"
       }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -4380,6 +4724,27 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "license": "MIT"
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4388,6 +4753,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -4439,6 +4813,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/iserror": {
+      "version": "0.0.2",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/iserror/-/iserror-0.0.2.tgz",
+      "integrity": "sha512-oKGGrFVaWwETimP3SiWwjDeY27ovZoyZPHtxblC4hCq9fXxed/jasx+ATWFFjCVSRZng8VTMsN1nDnGo6zMBSw==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -4460,7 +4840,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/jsesc": {
@@ -4481,6 +4860,12 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -4818,6 +5203,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "license": "MIT"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -5158,6 +5549,42 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/normalize-package-data": {
+      "version": "3.0.3",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -5508,9 +5935,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5528,9 +5952,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5548,9 +5969,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5568,9 +5986,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5588,9 +6003,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5608,9 +6020,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5628,9 +6037,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5648,9 +6054,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5834,6 +6237,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5951,6 +6372,16 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -6148,6 +6579,45 @@
         "webpack": {
           "optional": true
         }
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "7.1.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/read-pkg/-/read-pkg-7.1.0.tgz",
+      "integrity": "sha512-5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.1",
+        "normalize-package-data": "^3.0.2",
+        "parse-json": "^5.2.0",
+        "type-fest": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/require-from-string": {
@@ -6368,6 +6838,53 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/stack-generator": {
+      "version": "2.0.10",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/stackframe": {
+      "version": "1.3.4",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.3.2",
@@ -6682,6 +7199,16 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
@@ -6778,6 +7305,73 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -6789,7 +7383,6 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -6799,6 +7392,68 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -336,7 +336,7 @@
     },
     "node_modules/@bugsnag/browser": {
       "version": "7.25.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/@bugsnag/browser/-/browser-7.25.0.tgz",
+      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.25.0.tgz",
       "integrity": "sha512-PzzWy5d9Ly1CU1KkxTB6ZaOw/dO+CYSfVtqxVJccy832e6+7rW/dvSw5Jy7rsNhgcKSKjZq86LtNkPSvritOLA==",
       "license": "MIT",
       "dependencies": {
@@ -345,7 +345,7 @@
     },
     "node_modules/@bugsnag/core": {
       "version": "7.25.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/@bugsnag/core/-/core-7.25.0.tgz",
+      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.25.0.tgz",
       "integrity": "sha512-JZLak1b5BVzy77CPcklViZrppac/pE07L3uSDmfSvFYSCGReXkik2txOgV05VlF9EDe36dtUAIIV7iAPDfFpQQ==",
       "license": "MIT",
       "dependencies": {
@@ -358,13 +358,13 @@
     },
     "node_modules/@bugsnag/cuid": {
       "version": "3.2.2",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/@bugsnag/cuid/-/cuid-3.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.2.2.tgz",
       "integrity": "sha512-7onuYLTMqMmHE9BBPG0YER4nFsU1rB+me1/YIeMusqcLbVbKKuG9u9+BDVDpje5e0llkkrVNOKYwmzM9DRIo7A==",
       "license": "MIT"
     },
     "node_modules/@bugsnag/js": {
       "version": "7.25.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/@bugsnag/js/-/js-7.25.0.tgz",
+      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.25.0.tgz",
       "integrity": "sha512-d8n8SyKdRUz8jMacRW1j/Sj/ckhKbIEp49+Dacp3CS8afRgfMZ//NXhUFFXITsDP5cXouaejR9fx4XVapYXNgg==",
       "license": "MIT",
       "dependencies": {
@@ -374,7 +374,7 @@
     },
     "node_modules/@bugsnag/node": {
       "version": "7.25.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/@bugsnag/node/-/node-7.25.0.tgz",
+      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-7.25.0.tgz",
       "integrity": "sha512-KlxBaJ8EREEsfKInybAjTO9LmdDXV3cUH5+XNXyqUZrcRVuPOu4j4xvljh+n24ifok/wbFZTKVXUzrN4iKIeIA==",
       "license": "MIT",
       "dependencies": {
@@ -388,7 +388,7 @@
     },
     "node_modules/@bugsnag/safe-json-stringify": {
       "version": "6.1.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.1.0.tgz",
       "integrity": "sha512-ImA35rnM7bGr+J30R979FQ95BhRB4UO1KfJA0J2sVqc8nwnrS9hhE5mkTmQWMs8Vh1Da+hkLKs5jJB4JjNZp4A==",
       "license": "MIT"
     },
@@ -1175,7 +1175,7 @@
     },
     "node_modules/@netlify/build-info": {
       "version": "8.1.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/@netlify/build-info/-/build-info-8.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@netlify/build-info/-/build-info-8.1.0.tgz",
       "integrity": "sha512-VwEKqeynrVEGerOsErMfzlfTaE1IV9xOKnareDy1rdm+BEQAMyfwG1H+75G1M9JoCrNzLPn5kR3F61suOeBbfA==",
       "license": "MIT",
       "dependencies": {
@@ -1198,13 +1198,13 @@
     },
     "node_modules/@netlify/build-info/node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/balanced-match/-/balanced-match-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
     "node_modules/@netlify/build-info/node_modules/brace-expansion": {
       "version": "2.1.2",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
       "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "license": "MIT",
       "dependencies": {
@@ -1213,7 +1213,7 @@
     },
     "node_modules/@netlify/build-info/node_modules/dot-prop": {
       "version": "7.2.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/dot-prop/-/dot-prop-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-7.2.0.tgz",
       "integrity": "sha512-Ol/IPXUARn9CSbkrdV4VJo7uCy1I3VuSiWCaFSg+8BdUOzF9n3jefIpcgAydvUZbTdEBZs2vEiTiS9m61ssiDA==",
       "license": "MIT",
       "dependencies": {
@@ -1228,7 +1228,7 @@
     },
     "node_modules/@netlify/build-info/node_modules/find-up": {
       "version": "6.3.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/find-up/-/find-up-6.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
       "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
       "license": "MIT",
       "dependencies": {
@@ -1244,7 +1244,7 @@
     },
     "node_modules/@netlify/build-info/node_modules/locate-path": {
       "version": "7.2.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/locate-path/-/locate-path-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-7.2.0.tgz",
       "integrity": "sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==",
       "license": "MIT",
       "dependencies": {
@@ -1259,7 +1259,7 @@
     },
     "node_modules/@netlify/build-info/node_modules/minimatch": {
       "version": "9.0.9",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/minimatch/-/minimatch-9.0.9.tgz",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
       "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "license": "ISC",
       "dependencies": {
@@ -1274,7 +1274,7 @@
     },
     "node_modules/@netlify/build-info/node_modules/p-limit": {
       "version": "4.0.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/p-limit/-/p-limit-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
       "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
       "license": "MIT",
       "dependencies": {
@@ -1289,7 +1289,7 @@
     },
     "node_modules/@netlify/build-info/node_modules/p-locate": {
       "version": "6.0.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/p-locate/-/p-locate-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
       "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
       "license": "MIT",
       "dependencies": {
@@ -1304,7 +1304,7 @@
     },
     "node_modules/@netlify/build-info/node_modules/path-exists": {
       "version": "5.0.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/path-exists/-/path-exists-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
       "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
       "license": "MIT",
       "engines": {
@@ -1313,7 +1313,7 @@
     },
     "node_modules/@netlify/build-info/node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/semver/-/semver-7.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
@@ -1325,7 +1325,7 @@
     },
     "node_modules/@netlify/build-info/node_modules/type-fest": {
       "version": "2.19.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -1337,7 +1337,7 @@
     },
     "node_modules/@netlify/build-info/node_modules/yocto-queue": {
       "version": "1.2.2",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
       "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
       "license": "MIT",
       "engines": {
@@ -1349,7 +1349,7 @@
     },
     "node_modules/@netlify/plugin-csp-nonce": {
       "version": "1.6.2",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/@netlify/plugin-csp-nonce/-/plugin-csp-nonce-1.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/@netlify/plugin-csp-nonce/-/plugin-csp-nonce-1.6.2.tgz",
       "integrity": "sha512-d4DCoJmqXqtxIjTeJ7Hyo0d9EvF+9rEhSuiLYnUGa2pdkNI65PzO23TAgIdVpnqdpSiS8/PMfvvr5xoE1F418w==",
       "license": "MIT",
       "dependencies": {
@@ -3180,7 +3180,7 @@
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "license": "MIT"
     },
@@ -3601,7 +3601,7 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
       "dependencies": {
@@ -3729,7 +3729,7 @@
     },
     "node_modules/byline": {
       "version": "5.0.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/byline/-/byline-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
       "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
       "license": "MIT",
       "engines": {
@@ -3813,7 +3813,7 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/cliui/-/cliui-8.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "license": "ISC",
       "dependencies": {
@@ -3827,7 +3827,7 @@
     },
     "node_modules/cliui/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
       "engines": {
@@ -3836,7 +3836,7 @@
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
       "dependencies": {
@@ -3850,7 +3850,7 @@
     },
     "node_modules/cliui/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
@@ -3862,7 +3862,7 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/color-convert/-/color-convert-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "license": "MIT",
       "dependencies": {
@@ -3874,7 +3874,7 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/color-name/-/color-name-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
@@ -4076,13 +4076,13 @@
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
       "dependencies": {
@@ -4118,7 +4118,7 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/error-ex/-/error-ex-1.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
       "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "license": "MIT",
       "dependencies": {
@@ -4127,7 +4127,7 @@
     },
     "node_modules/error-stack-parser": {
       "version": "2.1.4",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
       "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
       "license": "MIT",
       "dependencies": {
@@ -4557,7 +4557,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/function-bind/-/function-bind-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
       "funding": {
@@ -4576,7 +4576,7 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "license": "ISC",
       "engines": {
@@ -4631,7 +4631,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.4",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/hasown/-/hasown-2.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
       "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
@@ -4660,7 +4660,7 @@
     },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
       "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
       "license": "ISC",
       "dependencies": {
@@ -4672,7 +4672,7 @@
     },
     "node_modules/hosted-git-info/node_modules/lru-cache": {
       "version": "6.0.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/lru-cache/-/lru-cache-6.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "license": "ISC",
       "dependencies": {
@@ -4684,7 +4684,7 @@
     },
     "node_modules/hosted-git-info/node_modules/yallist": {
       "version": "4.0.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/yallist/-/yallist-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
     },
@@ -4726,13 +4726,13 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "license": "MIT"
     },
     "node_modules/is-core-module": {
       "version": "2.16.2",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/is-core-module/-/is-core-module-2.16.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
       "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "license": "MIT",
       "dependencies": {
@@ -4757,7 +4757,7 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "license": "MIT",
       "engines": {
@@ -4815,7 +4815,7 @@
     },
     "node_modules/iserror": {
       "version": "0.0.2",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/iserror/-/iserror-0.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/iserror/-/iserror-0.0.2.tgz",
       "integrity": "sha512-oKGGrFVaWwETimP3SiWwjDeY27ovZoyZPHtxblC4hCq9fXxed/jasx+ATWFFjCVSRZng8VTMsN1nDnGo6zMBSw==",
       "license": "MIT"
     },
@@ -4864,7 +4864,7 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
     },
@@ -5206,7 +5206,7 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "license": "MIT"
     },
@@ -5553,7 +5553,7 @@
     },
     "node_modules/normalize-package-data": {
       "version": "3.0.3",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
       "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5568,7 +5568,7 @@
     },
     "node_modules/normalize-package-data/node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/semver/-/semver-7.8.5.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
@@ -5580,7 +5580,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
       "dependencies": {
@@ -6239,7 +6239,7 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/parse-json/-/parse-json-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
       "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
       "license": "MIT",
       "dependencies": {
@@ -6376,7 +6376,7 @@
     },
     "node_modules/pump": {
       "version": "3.0.4",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/pump/-/pump-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "license": "MIT",
       "dependencies": {
@@ -6583,7 +6583,7 @@
     },
     "node_modules/read-pkg": {
       "version": "7.1.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/read-pkg/-/read-pkg-7.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-7.1.0.tgz",
       "integrity": "sha512-5iOehe+WF75IccPc30bWTbpdDQLOCc3Uu8bi3Dte3Eueij81yx1Mrufk8qBx/YAbR4uL1FdUr+7BKXDwEtisXg==",
       "license": "MIT",
       "dependencies": {
@@ -6601,7 +6601,7 @@
     },
     "node_modules/read-pkg/node_modules/type-fest": {
       "version": "2.19.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/type-fest/-/type-fest-2.19.0.tgz",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
       "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
       "license": "(MIT OR CC0-1.0)",
       "engines": {
@@ -6613,7 +6613,7 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "license": "MIT",
       "engines": {
@@ -6841,7 +6841,7 @@
     },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
       "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -6851,13 +6851,13 @@
     },
     "node_modules/spdx-exceptions": {
       "version": "2.5.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
       "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
       "license": "CC-BY-3.0"
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "license": "MIT",
       "dependencies": {
@@ -6867,13 +6867,13 @@
     },
     "node_modules/spdx-license-ids": {
       "version": "3.0.23",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
       "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "license": "CC0-1.0"
     },
     "node_modules/stack-generator": {
       "version": "2.0.10",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/stack-generator/-/stack-generator-2.0.10.tgz",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
       "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
       "license": "MIT",
       "dependencies": {
@@ -6882,7 +6882,7 @@
     },
     "node_modules/stackframe": {
       "version": "1.3.4",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/stackframe/-/stackframe-1.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "license": "MIT"
     },
@@ -7201,7 +7201,7 @@
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "license": "Apache-2.0",
       "dependencies": {
@@ -7307,7 +7307,7 @@
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
       "dependencies": {
@@ -7324,7 +7324,7 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
       "engines": {
@@ -7333,7 +7333,7 @@
     },
     "node_modules/wrap-ansi/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
       "dependencies": {
@@ -7347,7 +7347,7 @@
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {
@@ -7359,13 +7359,13 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/y18n/-/y18n-5.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "license": "ISC",
       "engines": {
@@ -7396,7 +7396,7 @@
     },
     "node_modules/yargs": {
       "version": "17.7.3",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/yargs/-/yargs-17.7.3.tgz",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
       "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "license": "MIT",
       "dependencies": {
@@ -7414,7 +7414,7 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "license": "ISC",
       "engines": {
@@ -7423,7 +7423,7 @@
     },
     "node_modules/yargs/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
       "engines": {
@@ -7432,7 +7432,7 @@
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/string-width/-/string-width-4.2.3.tgz",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
       "dependencies": {
@@ -7446,7 +7446,7 @@
     },
     "node_modules/yargs/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "resolved": "https://nlb.jfrog.io/artifactory/api/npm/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@firecms/neat": "^1.0.0",
+    "@netlify/plugin-csp-nonce": "^1.6.2",
     "lucide-react": "^1.20.0",
     "motion": "^12.40.0",
     "next": "^16.2.9",

--- a/src/components/header/desktop-navigation.tsx
+++ b/src/components/header/desktop-navigation.tsx
@@ -1,5 +1,4 @@
 import { ChevronDown } from 'lucide-react'
-import { motion } from 'motion/react'
 import { topLevelNavHref } from '../../lib/expertise-links'
 import { useLocation } from '../../lib/navigation'
 import type { HeaderProps, NavItem } from './types'
@@ -32,17 +31,17 @@ export function DesktopNavigation({
         }`
 
         const chevron = item.hasDropdown ? (
-          <motion.span
-            animate={{ rotate: isActive ? 180 : 0 }}
-            className="flex"
-            transition={{ type: 'spring', stiffness: 320, damping: 24 }}
+          <span
+            className={`flex transition-transform duration-300 ${
+              isActive ? 'rotate-180' : 'rotate-0'
+            }`}
           >
             <ChevronDown
               aria-hidden="true"
               className="size-4 shrink-0"
               strokeWidth={2.25}
             />
-          </motion.span>
+          </span>
         ) : null
 
         if (directHref) {

--- a/src/components/header/mobile-language-switcher.tsx
+++ b/src/components/header/mobile-language-switcher.tsx
@@ -63,17 +63,17 @@ export function MobileLanguageSwitcher({
           strokeWidth={2.25}
         />
         <span className="uppercase">{current?.label ?? language}</span>
-        <motion.span
-          animate={{ rotate: open ? 180 : 0 }}
-          className="flex"
-          transition={{ type: 'spring', stiffness: 320, damping: 24 }}
+        <span
+          className={`flex transition-transform duration-300 ${
+            open ? 'rotate-180' : 'rotate-0'
+          }`}
         >
           <ChevronDown
             aria-hidden="true"
             className="size-4 text-neutral-500"
             strokeWidth={2.25}
           />
-        </motion.span>
+        </span>
       </Button>
 
       <AnimatePresence>

--- a/src/components/header/mobile-menu-button.tsx
+++ b/src/components/header/mobile-menu-button.tsx
@@ -1,5 +1,4 @@
 import { Menu, X } from 'lucide-react'
-import { AnimatePresence, motion } from 'motion/react'
 import { Button } from '../button'
 
 type MobileMenuButtonProps = {
@@ -8,15 +7,11 @@ type MobileMenuButtonProps = {
   onClick: () => void
 }
 
-const ICON_SPRING = { type: 'spring', stiffness: 380, damping: 26 } as const
-
 export function MobileMenuButton({
   ariaLabel,
   isOpen,
   onClick,
 }: MobileMenuButtonProps) {
-  const Icon = isOpen ? X : Menu
-
   return (
     <Button
       ariaExpanded={isOpen}
@@ -27,18 +22,24 @@ export function MobileMenuButton({
       size="lg"
       tone="secondary"
     >
-      <AnimatePresence initial={false} mode="popLayout">
-        <motion.span
-          animate={{ opacity: 1, rotate: 0, scale: 1 }}
-          className="flex"
-          exit={{ opacity: 0, rotate: isOpen ? -90 : 90, scale: 0.6 }}
-          initial={{ opacity: 0, rotate: isOpen ? 90 : -90, scale: 0.6 }}
-          key={isOpen ? 'close' : 'open'}
-          transition={ICON_SPRING}
-        >
-          <Icon aria-hidden="true" className="size-4" strokeWidth={2.25} />
-        </motion.span>
-      </AnimatePresence>
+      <span aria-hidden="true" className="relative flex size-4">
+        <Menu
+          className={`absolute inset-0 size-4 transition duration-300 ease-out ${
+            isOpen
+              ? 'rotate-90 scale-75 opacity-0'
+              : 'rotate-0 scale-100 opacity-100'
+          }`}
+          strokeWidth={2.25}
+        />
+        <X
+          className={`absolute inset-0 size-4 transition duration-300 ease-out ${
+            isOpen
+              ? 'rotate-0 scale-100 opacity-100'
+              : '-rotate-90 scale-75 opacity-0'
+          }`}
+          strokeWidth={2.25}
+        />
+      </span>
     </Button>
   )
 }

--- a/src/components/header/mobile-menu.tsx
+++ b/src/components/header/mobile-menu.tsx
@@ -13,8 +13,6 @@ import type { HeaderProps, NavItem } from './types'
 
 const EASE = [0.22, 1, 0.36, 1] as const
 
-const HEADER_OFFSET = '73px'
-
 type MobileMenuProps = {
   activeItem: NavItem | null
   blogHref: string
@@ -102,10 +100,9 @@ export function MobileMenu({
       {isOpen ? (
         <motion.div
           animate={{ opacity: 1 }}
-          className="fixed inset-x-0 bottom-0 z-30 flex flex-col bg-white lg:hidden"
+          className="fixed inset-x-0 bottom-0 top-[73px] z-30 flex flex-col bg-white lg:hidden"
           exit={{ opacity: 0, transition: { duration: 0.18, ease: EASE } }}
           initial={{ opacity: 0 }}
-          style={{ top: HEADER_OFFSET }}
           transition={{ duration: 0.22, ease: EASE }}
         >
           <div className="relative flex-1 overflow-hidden">

--- a/src/components/insights/article-card.tsx
+++ b/src/components/insights/article-card.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image'
 import type { StaticImageData } from 'next/image'
 import type { InsightPost } from '../../views/insights/types'
 import { cardHover } from '../cards/card-hover'
@@ -25,13 +24,15 @@ export function ArticleCard({
   return (
     <article className={`group relative flex flex-col ${cardHover}`}>
       <div className="relative aspect-[16/10] overflow-hidden rounded-xl border border-neutral-200 bg-neutral-100">
-        <Image
+        {/* next/image injects a style attribute that violates the enforced CSP. */}
+        <img
           alt=""
-          className="size-full object-cover"
-          fill
+          className="block size-full object-cover"
+          decoding="async"
+          height={thumbnail.height}
           loading="lazy"
-          sizes="(min-width: 1024px) 352px, (min-width: 640px) 50vw, 100vw"
-          src={thumbnail}
+          src={thumbnail.src}
+          width={thumbnail.width}
         />
       </div>
 

--- a/src/components/motion.tsx
+++ b/src/components/motion.tsx
@@ -1,13 +1,108 @@
-import { motion, type Variants } from 'motion/react'
-import type { ReactNode } from 'react'
+'use client'
 
-const EASE = [0.22, 1, 0.36, 1] as const
+import type { Variants } from 'motion/react'
+import {
+  useEffect,
+  useRef,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+} from 'react'
 
-const VIEWPORT = { once: true, margin: '0px 0px -12% 0px' } as const
+const EASING = 'cubic-bezier(0.22, 1, 0.36, 1)'
+const REVEAL_MARGIN = '0px 0px -12% 0px'
+const LOGO_MARGIN = '0px 0px -10% 0px'
 
-export const revealItem: Variants = {
-  hidden: { opacity: 0, y: 24 },
-  visible: { opacity: 1, y: 0, transition: { duration: 0.55, ease: EASE } },
+const REVEAL_KEYFRAMES: Keyframe[] = [
+  { opacity: 0, transform: 'translateY(24px)' },
+  { opacity: 1, transform: 'none' },
+]
+
+const LOGO_KEYFRAMES: Keyframe[] = [
+  { opacity: 0, transform: 'scale(0.9)' },
+  { opacity: 1, transform: 'none' },
+]
+
+// Existing card components still accept this prop. RevealGroup now animates
+// their rendered elements without serializing Motion styles into the HTML.
+export const revealItem: Variants = {}
+
+type ViewportAnimationOptions = {
+  delay?: number
+  duration: number
+  rootMargin: string
+  stagger?: number
+  target?: 'self' | 'children'
+}
+
+function useViewportAnimation<T extends HTMLElement>(
+  keyframes: Keyframe[],
+  {
+    delay = 0,
+    duration,
+    rootMargin,
+    stagger = 0,
+    target = 'self',
+  }: ViewportAnimationOptions,
+) {
+  const ref = useRef<T>(null)
+
+  useEffect(() => {
+    const host = ref.current
+    const reducedMotion = window.matchMedia(
+      '(prefers-reduced-motion: reduce)',
+    ).matches
+
+    if (
+      !host ||
+      reducedMotion ||
+      !('IntersectionObserver' in window) ||
+      typeof host.animate !== 'function'
+    ) {
+      return
+    }
+
+    const targets =
+      target === 'children'
+        ? Array.from(host.children).filter(
+            (child): child is HTMLElement => child instanceof HTMLElement,
+          )
+        : [host]
+    let animations: Animation[] = []
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry?.isIntersecting) {
+          return
+        }
+
+        animations = targets.map((element, index) => {
+          const animation = element.animate(keyframes, {
+            delay: (delay + index * stagger) * 1000,
+            duration,
+            easing: EASING,
+            fill: 'both',
+          })
+
+          void animation.finished
+            .then(() => animation.cancel())
+            .catch(() => undefined)
+
+          return animation
+        })
+        observer.disconnect()
+      },
+      { rootMargin },
+    )
+
+    observer.observe(host)
+
+    return () => {
+      observer.disconnect()
+      animations.forEach((animation) => animation.cancel())
+    }
+  }, [delay, duration, keyframes, rootMargin, stagger, target])
+
+  return ref
 }
 
 type RevealProps = {
@@ -17,49 +112,52 @@ type RevealProps = {
 }
 
 export function Reveal({ children, className, delay = 0 }: RevealProps) {
+  const ref = useViewportAnimation<HTMLDivElement>(REVEAL_KEYFRAMES, {
+    delay,
+    duration: 600,
+    rootMargin: REVEAL_MARGIN,
+  })
+
   return (
-    <motion.div
-      className={className}
-      initial="hidden"
-      variants={{
-        hidden: { opacity: 0, y: 24 },
-        visible: {
-          opacity: 1,
-          y: 0,
-          transition: { duration: 0.6, ease: EASE, delay },
-        },
-      }}
-      viewport={VIEWPORT}
-      whileInView="visible"
-    >
+    <div className={className} ref={ref}>
       {children}
-    </motion.div>
+    </div>
   )
 }
 
 export function RevealGroup({ children, className, delay = 0 }: RevealProps) {
+  const ref = useViewportAnimation<HTMLDivElement>(REVEAL_KEYFRAMES, {
+    delay,
+    duration: 550,
+    rootMargin: REVEAL_MARGIN,
+    stagger: 0.08,
+    target: 'children',
+  })
+
   return (
-    <motion.div
-      className={className}
-      initial="hidden"
-      variants={{
-        hidden: {},
-        visible: {
-          transition: { staggerChildren: 0.08, delayChildren: delay },
-        },
-      }}
-      viewport={VIEWPORT}
-      whileInView="visible"
-    >
+    <div className={className} ref={ref}>
       {children}
-    </motion.div>
+    </div>
   )
 }
 
 export function RevealItem({ children, className }: RevealProps) {
-  return (
-    <motion.div className={className} variants={revealItem}>
-      {children}
-    </motion.div>
-  )
+  return <div className={className}>{children}</div>
+}
+
+type RevealScaleImageProps = ComponentPropsWithoutRef<'img'> & {
+  delay?: number
+}
+
+export function RevealScaleImage({
+  delay = 0,
+  ...props
+}: RevealScaleImageProps) {
+  const ref = useViewportAnimation<HTMLImageElement>(LOGO_KEYFRAMES, {
+    delay,
+    duration: 450,
+    rootMargin: LOGO_MARGIN,
+  })
+
+  return <img ref={ref} {...props} />
 }

--- a/src/components/site-chrome.tsx
+++ b/src/components/site-chrome.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { MotionConfig } from 'motion/react'
 import { useEffect, type ReactNode } from 'react'
 import type { PageContent } from '../content'
 import type { LandingContent } from '../content/landing/landing'
@@ -30,10 +29,6 @@ export function SiteChrome({
   children,
 }: SiteChromeProps) {
   const switchLanguage = useLanguageSwitch()
-  const cspNonce =
-    typeof document === 'undefined'
-      ? undefined
-      : document.querySelector<HTMLScriptElement>('script[nonce]')?.nonce
 
   useEffect(() => {
     document.documentElement.lang = language
@@ -67,18 +62,16 @@ export function SiteChrome({
   }, [])
 
   return (
-    <MotionConfig nonce={cspNonce}>
-      <div className="min-h-screen overflow-hidden bg-white text-neutral-900">
-        <LinkInterceptor />
-        <Header
-          content={nav}
-          language={language}
-          languages={LANGUAGES}
-          onLanguageChange={switchLanguage}
-        />
-        <main>{children}</main>
-        <Footer contact={contact} content={footer} language={language} />
-      </div>
-    </MotionConfig>
+    <div className="min-h-screen overflow-hidden bg-white text-neutral-900">
+      <LinkInterceptor />
+      <Header
+        content={nav}
+        language={language}
+        languages={LANGUAGES}
+        onLanguageChange={switchLanguage}
+      />
+      <main>{children}</main>
+      <Footer contact={contact} content={footer} language={language} />
+    </div>
   )
 }

--- a/src/components/site-chrome.tsx
+++ b/src/components/site-chrome.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { MotionConfig } from 'motion/react'
 import { useEffect, type ReactNode } from 'react'
 import type { PageContent } from '../content'
 import type { LandingContent } from '../content/landing/landing'
@@ -29,6 +30,10 @@ export function SiteChrome({
   children,
 }: SiteChromeProps) {
   const switchLanguage = useLanguageSwitch()
+  const cspNonce =
+    typeof document === 'undefined'
+      ? undefined
+      : document.querySelector<HTMLScriptElement>('script[nonce]')?.nonce
 
   useEffect(() => {
     document.documentElement.lang = language
@@ -62,16 +67,18 @@ export function SiteChrome({
   }, [])
 
   return (
-    <div className="min-h-screen overflow-hidden bg-white text-neutral-900">
-      <LinkInterceptor />
-      <Header
-        content={nav}
-        language={language}
-        languages={LANGUAGES}
-        onLanguageChange={switchLanguage}
-      />
-      <main>{children}</main>
-      <Footer contact={contact} content={footer} language={language} />
-    </div>
+    <MotionConfig nonce={cspNonce}>
+      <div className="min-h-screen overflow-hidden bg-white text-neutral-900">
+        <LinkInterceptor />
+        <Header
+          content={nav}
+          language={language}
+          languages={LANGUAGES}
+          onLanguageChange={switchLanguage}
+        />
+        <main>{children}</main>
+        <Footer contact={contact} content={footer} language={language} />
+      </div>
+    </MotionConfig>
   )
 }

--- a/src/views/references/clients-industries/sections/logo-wall.tsx
+++ b/src/views/references/clients-industries/sections/logo-wall.tsx
@@ -1,14 +1,11 @@
-import { motion } from 'motion/react'
 import type { LogoWallBlock } from '../../types'
+import { RevealScaleImage } from '../../../../components/motion'
 import {
   referenceNameByStem as nameByStem,
   referenceStemsByFolder as stemsByFolder,
   referenceUrlByStem as urlByStem,
 } from '../../../../lib/reference-logos'
 import { Heading, Section, type SectionBg } from './section-shell'
-
-const EASE = [0.22, 1, 0.36, 1] as const
-const VIEWPORT = { once: true, margin: '0px 0px -10% 0px' } as const
 
 export function LogoWallSection({
   block,
@@ -44,19 +41,12 @@ export function LogoWallSection({
             className="group relative flex h-28 items-center justify-center overflow-hidden border-b border-r border-neutral-200 px-6 transition-colors duration-300 hover:bg-white"
             key={logo.stem}
           >
-            <motion.img
+            <RevealScaleImage
               alt={logo.name}
               className="max-h-10 w-auto max-w-[78%] object-contain grayscale transition-[filter] duration-300 group-hover:grayscale-0"
+              delay={(index % 8) * 0.05}
               draggable={false}
-              initial={{ opacity: 0, scale: 0.9 }}
               src={logo.src}
-              transition={{
-                duration: 0.45,
-                ease: EASE,
-                delay: (index % 8) * 0.05,
-              }}
-              viewport={VIEWPORT}
-              whileInView={{ opacity: 1, scale: 1 }}
             />
             <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-neutral-900/70 px-4 text-center opacity-0 transition-opacity duration-300 group-hover:opacity-100">
               <span className="text-lg font-semibold text-white">

--- a/src/views/references/research-innovation/sections/logo-wall.tsx
+++ b/src/views/references/research-innovation/sections/logo-wall.tsx
@@ -1,14 +1,11 @@
-import { motion } from 'motion/react'
 import type { LogoWallBlock } from '../../types'
+import { RevealScaleImage } from '../../../../components/motion'
 import {
   referenceNameByStem as nameByStem,
   referenceStemsByFolder as stemsByFolder,
   referenceUrlByStem as urlByStem,
 } from '../../../../lib/reference-logos'
 import { Heading, Section, type SectionBg } from './section-shell'
-
-const EASE = [0.22, 1, 0.36, 1] as const
-const VIEWPORT = { once: true, margin: '0px 0px -10% 0px' } as const
 
 export function LogoWallSection({
   block,
@@ -44,19 +41,12 @@ export function LogoWallSection({
             className="group relative flex h-28 items-center justify-center overflow-hidden border-b border-r border-neutral-200 px-6 transition-colors duration-300 hover:bg-white"
             key={logo.stem}
           >
-            <motion.img
+            <RevealScaleImage
               alt={logo.name}
               className="max-h-10 w-auto max-w-[78%] object-contain grayscale transition-[filter] duration-300 group-hover:grayscale-0"
+              delay={(index % 8) * 0.05}
               draggable={false}
-              initial={{ opacity: 0, scale: 0.9 }}
               src={logo.src}
-              transition={{
-                duration: 0.45,
-                ease: EASE,
-                delay: (index % 8) * 0.05,
-              }}
-              viewport={VIEWPORT}
-              whileInView={{ opacity: 1, scale: 1 }}
             />
             <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-neutral-900/60 px-4 text-center opacity-0 transition-opacity duration-300 group-hover:opacity-100">
               <span className="text-lg font-semibold text-white">


### PR DESCRIPTION
### **CSP configuration and inline style cleanup**

**Summary**
Added a strict CSP through netlify.toml.
Added @netlify/plugin-csp-nonce for nonce-based scripts with strict-dynamic.
Added security headers including X-Content-Type-Options, Referrer-Policy, and Permissions-Policy.
Allowed the Netlify deploy-preview frame while keeping framing blocked elsewhere.
Replaced Motion-generated inline styles with IntersectionObserver, Web Animations API, and CSS transitions.
Removed remaining inline styles from navigation, images, and the 404 page.

**Why**
The CSP disallows unsafe-inline to satisfy security scanners. Motion previously generated inline style attributes for reveal animations, causing CSP violations. The rewrite preserves the same animations and reduced-motion behavior without weakening the policy.

**Verification**

- Tested on chrome - netlify predeplo - manually.
- Tested on Firefox - netlify predeploy -manually.
- Exported HTML contains no inline style attributes - GPT.

SecurityHeaders scans tested on:

- https://securityheaders.com/
- https://centralcsp.com/features/scanner
- https://csp-evaluator.withgoogle.com/
